### PR TITLE
Removing 1 soundex

### DIFF
--- a/lib/soundex.json
+++ b/lib/soundex.json
@@ -4,7 +4,6 @@
     "asshole",
     "bitch",
     "fuck",
-    "hoe",
     "slut",
     "whore"
   ]


### PR DESCRIPTION
Fixes https://github.com/web-mech/badwords/issues/5

'hi' has soundex `H000`
'hoe' has soundex `H000`

Soundex has a lot of overlap (e.g. `ass` === `ask`) - i'd suggest something more accurate