### PR TITLE
add options.

### DIFF
--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -4,7 +4,7 @@ var Filter = (function() {
     this.list = options.emptyList && [] || Array.prototype.concat.apply(require('./lang.json').words, [require('badwords-list').array, options.list || []]);
     this.placeHolder = options.placeHolder || '*';
     this.regex = options.regex || /[^a-zA-z0-9|\$|\@]|\^/g;
-    this.replaceregex = options.replaceregex || /\w/g;
+    this.replaceRegex = options.replaceRegex || /\w/g;
   }
 
   Filter.prototype.isProfane = function isProfane(string) {
@@ -19,7 +19,7 @@ var Filter = (function() {
   };
 
   Filter.prototype.replaceWord = function replaceWord(string) {
-    return string.replace(this.regex, '').replace(this.replaceregex, this.placeHolder);
+    return string.replace(this.regex, '').replace(this.replaceRegex, this.placeHolder);
   };
 
   Filter.prototype.clean = function clean(string) {

--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -4,6 +4,7 @@ var Filter = (function() {
     this.list = options.emptyList && [] || Array.prototype.concat.apply(require('./lang.json').words, [require('badwords-list').array, options.list || []]);
     this.placeHolder = options.placeHolder || '*';
     this.regex = options.regex || /[^a-zA-z0-9|\$|\@]|\^/g;
+    this.replaceregex = options.replaceregex || /\w/g;
   }
 
   Filter.prototype.isProfane = function isProfane(string) {
@@ -18,7 +19,7 @@ var Filter = (function() {
   };
 
   Filter.prototype.replaceWord = function replaceWord(string) {
-    return string.replace(this.regex, '').replace(/\w/g, this.placeHolder);
+    return string.replace(this.regex, '').replace(this.replaceregex, this.placeHolder);
   };
 
   Filter.prototype.clean = function clean(string) {


### PR DESCRIPTION
this option need because other language support.(like korean.)
it can be found in isProfane function when I change regex option into  "/[^a-zA-z0-9가-힣\$|\@]|\^/g"  but it is not replace in replaceWord function cuz that function uses fixed regex '/\w/g'. 
so, I added few line for anyone can change replace regex like /[A-Za-z0-9가-힣_]/g .
