### PR TITLE
Adding regex word boundary for isProfane

### DIFF
--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -26,7 +26,7 @@ var Filter = (function() {
    */
   Filter.prototype.isProfane = function isProfane(string) {
     return string
-      .split(' ')
+      .split(/\b/)
       .map(function(w) {
         return w.toLowerCase().replace(this.regex, '');
       }, this)

--- a/test/isProfane.js
+++ b/test/isProfane.js
@@ -31,5 +31,9 @@ describe('filter', function(){
 			});
 			assert(filter.isProfane('test'));
 		});
+
+		it('Should tokenize words according to regex word boundaries', function() {
+			assert(filter.isProfane("that person is an\nasshole"));
+		})
 	});
 });


### PR DESCRIPTION
Great lib,

Noticed there was a regex word boundary on clean but not isProfane, which broke for me just testing string with line breaks. Changed the split for isProfane and added a test.