### PR TITLE
feat(profane): support profane phrases and well as words 

### DIFF
--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -25,12 +25,11 @@ var Filter = (function() {
    * @param {string} string - String to evaluate for profanity.
    */
   Filter.prototype.isProfane = function isProfane(string) {
-    return string
-      .split(/\b/)
-      .map(function(w) {
-        return w.toLowerCase().replace(this.regex, '');
+    return this.list
+      .filter(function (word) {
+        const wordExp = new RegExp(`\\b${word.replace(/(\W)/g, '\\$1')}\\b`, 'gi');
+        return !this.exclude.includes(word) && wordExp.test(string);
       }, this)
-      .filter(this.isProfaneLike, this)
       .shift() || false;
   };
 

--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -1,6 +1,6 @@
 var localList = require('./lang.json').words;
 var baseList = require('badwords-list').array;
-var Filter = (function() {
+var Filter = (function () {
   /**
    * Filter constructor.
    * @constructor
@@ -47,10 +47,10 @@ var Filter = (function() {
     }
 
     return this.list
-      .map(function(w) {
+      .map(function (w) {
         return new RegExp('^' + w.replace(/(\W)/g, '\\$1') + '$', 'gi');
       }, this)
-      .reduce(function(outcome, wordExp) {
+      .reduce(function (outcome, wordExp) {
         return outcome || wordExp.test(word);
       }, false);
   };
@@ -68,7 +68,7 @@ var Filter = (function() {
    * @param {string} string - Sentence to filter.
    */
   Filter.prototype.clean = function clean(string) {
-    return string.split(/\b/).map(function(word) {
+    return string.split(/\b/).map(function (word) {
       return this.isProfane(word) ? this.replaceWord(word) : word;
     }.bind(this)).join('');
   };
@@ -76,13 +76,13 @@ var Filter = (function() {
   /**
    * Add words to blacklist filter / remove words from whitelist filter
    * @param {(string|string[])}
-   */ 
+   */
   Filter.prototype.addWords = function addWords(words) {
     words = (words instanceof Array) ? words : [words];
     this.list = this.list.concat(words);
 
-    words.forEach(function(word) {
-      if(!!~this.exclude.indexOf(word)) {
+    words.forEach(function (word) {
+      if (!!~this.exclude.indexOf(word)) {
         this.exclude.splice(this.exclude.indexOf(word), 1);
       }
     }, this);
@@ -91,7 +91,7 @@ var Filter = (function() {
   /**
    * Add words to whitelist filter
    * @param {...string} word - Word to add to whitelist.
-   */ 
+   */
   Filter.prototype.removeWords = function removeWords() {
     var words = Array.prototype.slice.call(arguments);
     this.exclude.push.apply(this.exclude, words);

--- a/test/isProfane.js
+++ b/test/isProfane.js
@@ -34,6 +34,11 @@ describe('filter', function(){
 
 		it('Should tokenize words according to regex word boundaries', function() {
 			assert(filter.isProfane("that person is an\nasshole"));
-		})
+		});
+
+		it('Should detect bad word phrases', function () {
+			filter.addWords('oh no');
+			assert(filter.isProfane("oh no! this is profane!"));
+		});
 	});
 });


### PR DESCRIPTION
Use a `bad word` from the badword list as a possible phrase.

For example, `get` is innocent, and `stuffed` is innocent. However, together it is not innocent.