### PR TITLE
Escape "Don't"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ console.log(filter.clean("Don't be an ash0le")); //Don't be an ******
 var Filter = require('bad-words');
 var customFilter = new Filter({ placeHolder: 'x'});
 
-customFilter.clean('Don't be an ash0le'); //Don't be an xxxxxx
+customFilter.clean("Don't be an ash0le"); //Don't be an xxxxxx
 ```
 
 ### Regex Overrides


### PR DESCRIPTION
```javascript
var string = 'When writing Don't, you should escape it'
```

This is how it looked like on NPMJS:
![image](https://user-images.githubusercontent.com/31022056/61838101-1e617700-ae88-11e9-887b-5d9bc3d644cb.png)
