### PR TITLE
build: add lint instruction to makefile to alphabetize and normalize words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ results
 
 npm-debug.log
 node_modules
+
+# Intermediate lint result
+lib/linted.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
 test:
 	@./node_modules/mocha/bin/_mocha -R $(REPORTER)
 
-.PHONY: test
+lint:
+	node -e 'console.log(`$${JSON.stringify({ words: \
+		require("./lib/lang.json").words.map(it => it.toLowerCase()).sort() \
+	}, null, 2)}`)' > lib/linted.json
+	# We use a temporary file because the redirect (>) overwrites lib/lang.json
+	# to be blank before the require() is evaluated, so we get an "Unexpected end
+	# of JSON input"
+	cp lib/linted.json lib/lang.json
+	rm lib/linted.json
+
+.PHONY: test lint


### PR DESCRIPTION
By alphabetizing the word list and normalizing each word by turning it to lowercase, we make it easier for contributors to add words to the library without worrying about duplicating entries.

If a contributor adds a new word and then runs `make lint`, they'll be able to clearly see in the diff if they added a duplicate since it will be right before or after the already existing word.