### PR TITLE
Don't crash w/strings with no word boundaries

### DIFF
--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -53,9 +53,11 @@ class Filter {
    * @param {string} string - Sentence to filter.
    */
   clean(string) {
+    const joinMatch = this.splitRegex.exec(string);
+    const joinString = (joinMatch && joinMatch[0]) || '';
     return string.split(this.splitRegex).map((word) => {
       return this.isProfane(word) ? this.replaceWord(word) : word;
-    }).join(this.splitRegex.exec(string)[0]);
+    }).join(joinString);
   }
 
   /**

--- a/test/filter.js
+++ b/test/filter.js
@@ -38,10 +38,16 @@ describe('filter', function(){
 
 		xit('Should filter words that are derivatives of words from the filter blacklist', function() {
 			assert(filter.clean('shitshit') === '********');
-    });
+		});
 
-    it('Shouldn\'t filter words that aren\'t profane.', function() {
+		it('Shouldn\'t filter words that aren\'t profane.', function() {
 			assert(filter.clean('hello there') === 'hello there');
-    });
+		});
+
+		it('Should handle strings with no word boundaries', function() {
+			assert(filter.clean('') === '');
+			assert(filter.clean('.') === '.');
+			assert(filter.clean('🙂') === '🙂');
+		});
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/web-mech/badwords/issues/93

```
TypeError: Cannot read property '0' of null
```