### PR TITLE
:beetle: (filter) Discard empty personalized words from list if added

### DIFF
--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -9,6 +9,7 @@ class Filter {
    * @param {object} options - Filter instance options
    * @param {boolean} options.emptyList - Instantiate filter with no blacklist
    * @param {array} options.list - Instantiate filter with custom list
+   * @param {array} options.exclude - Instantiate words to be excluded from list
    * @param {string} options.placeHolder - Character used to replace profane words.
    * @param {string} options.regex - Regular expression used to sanitize words before comparing them to blacklist.
    * @param {string} options.replaceRegex - Regular expression used to replace profane words with placeHolder.
@@ -72,6 +73,9 @@ class Filter {
       .forEach((word) => {
         if (this.exclude.includes(word)) {
           this.exclude.splice(this.exclude.indexOf(word), 1);
+        }
+        if (word.length === 0) {
+          this.list.splice(this.list.indexOf(word), 1);
         }
       });
   }

--- a/test/options.js
+++ b/test/options.js
@@ -19,6 +19,14 @@ describe('options', function() {
       assert(filter.clean('mot en français') == 'mot en *******');
     });
 
+    it('should discard empty string from personalized list, if present', function() {
+      var personalized = "kafir,,hello";
+      var myList = personalized.split(",");
+      filter = new Filter({ emptyList: true });
+      filter.addWords(...myList);
+      assert(filter.clean('nice try') == 'nice try');
+      assert(filter.clean('hello mister') == '***** mister');
+    })
 
   });
 });


### PR DESCRIPTION
w.r.t issue https://github.com/web-mech/badwords/issues/83

A personal list on addition of words if includes empty strings (by mistake) it causes the whole string to be marked as profane. Add support to discard such strings if present in the list.