### PR TITLE
Added "sexual" to filtered words in lang.json

### DIFF
--- a/lib/lang.json
+++ b/lib/lang.json
@@ -199,6 +199,7 @@
     "semen",
     "sex",
     "sexy",
+    "sexual",
     "Sh!t",
     "sh1t",
     "sh1ter",


### PR DESCRIPTION
Noticed that "sex" and "sexy" are listed, but not "sexual"