### PR TITLE
Improve split regrex

### DIFF
--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -18,7 +18,7 @@ class Filter {
     Object.assign(this, {
       list: options.emptyList && [] || Array.prototype.concat.apply(localList, [baseList, options.list || []]),
       exclude: options.exclude || [],
-      splitRegex: options.splitRegex || /\b|_/,
+      splitRegex: options.splitRegex || /\b|_/g,
       placeHolder: options.placeHolder || '*',
       regex: options.regex || /[^a-zA-Z0-9|\$|\@]|\^/g,
       replaceRegex: options.replaceRegex || /\w/g

--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -18,7 +18,7 @@ class Filter {
     Object.assign(this, {
       list: options.emptyList && [] || Array.prototype.concat.apply(localList, [baseList, options.list || []]),
       exclude: options.exclude || [],
-      splitRegex: options.splitRegex || /\b/,
+      splitRegex: options.splitRegex || /\b|_/,
       placeHolder: options.placeHolder || '*',
       regex: options.regex || /[^a-zA-Z0-9|\$|\@]|\^/g,
       replaceRegex: options.replaceRegex || /\w/g

--- a/test/filter.js
+++ b/test/filter.js
@@ -3,45 +3,50 @@ var Filter = require('../lib/badwords.js'),
 	filter = new Filter(),
 	assert = require('better-assert');
 
-describe('filter', function(){
-	describe('clean',function(){
-		it('Should replace a bad word within a sentence asterisks (******)',function(){
+describe('filter', function () {
+	describe('clean', function () {
+		it('Should replace a bad word within a sentence asterisks (******)', function () {
 			console.log(filter.clean('Don\'t be an ash0le'));
 			assert(filter.clean('Don\'t be an ash0le') === 'Don\'t be an ******');
 
 		});
 
-		it('Should replace multiple instances of any bad words within a sentence asterisks (******)',function(){
+		it('Should replace multiple instances of any bad words within a sentence asterisks (******)', function () {
 			assert(filter.clean('cnts ash0le knob xxx') === '**** ****** **** ***');
 		});
 
-		it('Should not replace anything within a sentence if there are no bad words',function(){
+		it('Should not replace anything within a sentence if there are no bad words', function () {
 			assert(filter.clean('The cat ran fast') === 'The cat ran fast');
 		});
 
-		it('Should replace a string with proper placeholder when overridden', function(){
-			var customFilter = new Filter({ placeHolder: 'x'});
+		it('Should replace a string with proper placeholder when overridden', function () {
+			var customFilter = new Filter({ placeHolder: 'x' });
 			assert(customFilter.clean('This is a hells good test') === 'This is a xxxxx good test');
 		});
 
-		it('Should allow an instance of filter with an empty blacklist', function() {
+		it('Should allow an instance of filter with an empty blacklist', function () {
 			var customFilter = new Filter({
 				emptyList: true
 			});
 			assert(customFilter.clean('This is a hells good test') === 'This is a hells good test');
 		});
 
-		it('Should tokenize words according to regex word boundaries',function(){
+		it('Should tokenize words according to regex word boundaries', function () {
 			assert(filter.clean('what a bitch...fuck you') === 'what a *****...**** you');
 			assert(filter.clean('<p>Don\'t be an asshole</p>') === '<p>Don\'t be an *******</p>');
 		});
 
-		xit('Should filter words that are derivatives of words from the filter blacklist', function() {
+		xit('Should filter words that are derivatives of words from the filter blacklist', function () {
 			assert(filter.clean('shitshit') === '********');
-    });
+		});
 
-    it('Shouldn\'t filter words that aren\'t profane.', function() {
+		it('Shouldn\'t filter words that aren\'t profane.', function () {
 			assert(filter.clean('hello there') === 'hello there');
-    });
+		});
+
+		it('Should seperate string with backspace or \_ sign', function () {
+			assert(filter.clean("Don't be an ash0le_word") === 'Don\'t be an ******word');
+
+		});
 	});
 });


### PR DESCRIPTION
Add support to clean words with character _

before:
console.log(filter.clean("Don't be an ash0le_word")); //Don't be an ash0le_word

after:
console.log(filter.clean("Don't be an ash0le_word")); //Don't be an ******word