### PR TITLE
Normal Words removed

### DIFF
--- a/lib/lang.json
+++ b/lib/lang.json
@@ -422,7 +422,6 @@
     "schaffer",
     "scheiss*",
     "schlampe",
-    "schmuck",
     "screw",
     "sh!t*",
     "sharmuta",


### PR DESCRIPTION
Schmuck: A normal German Word in english: Jewelry