### PR TITLE
Remove variation of "queer"

### DIFF
--- a/lib/lang.json
+++ b/lib/lang.json
@@ -188,7 +188,6 @@
     "pussy",
     "puuke",
     "puuker",
-    "qweir",
     "recktum",
     "rectum",
     "retard",


### PR DESCRIPTION
This is an addition to a previous commit https://github.com/web-mech/badwords/commit/bcd1cc3dbbacb74d3adcec67e0b2f32de7fef1de in which a variation of the word "queer" was missed.