### PR TITLE
Tagged template helper, CJS packaging fix, OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,22 +4,22 @@ on:
   push:
     branches: ['main']
 
+permissions:
+  contents: write # standard-version commits the version bump and pushes tags
+  id-token: write # required for npm trusted publishing (OIDC)
+
 jobs:
-  publish-gpr:
+  publish-npm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+      # Trusted publishing requires npm >= 11.5.1
+      - run: npm install -g npm@latest
       - run: yarn install
-      - run: yarn global add standard-version
       - run: git config --global user.email "action@github.com"
       - run: git config --global user.name "GitHub Action"
-      - uses: EndBug/add-and-commit@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ const filter = new Filter();
 console.log(filter.clean("Don't be an ash0le")); //Don't be an ******
 ```
 
+### Tagged templates
+
+Clean strings inline with a tagged template literal. The recommended form is
+`createFilter(options)`, which binds a tag to its own configured filter:
+
+```js
+import { createFilter } from 'bad-words'
+
+const filter = createFilter({ placeHolder: 'x', exclude: ['hells'] })
+
+filter`Don't be an ash0le` //Don't be an xxxxxx
+filter`you ${userInput}!` //interpolated values are cleaned too
+```
+
+A zero-config `filter` tag is also exported for quick use — it's equivalent to
+`createFilter()`:
+
+```js
+import { filter } from 'bad-words'
+
+filter`Don't be an ash0le` //Don't be an ******
+```
+
+The tag joins the template's literals and interpolated values, then cleans the
+whole string — output is identical to calling `.clean()` on the same text.
+
 ### Placeholder Overrides
 
 ```js

--- a/docs/superpowers/specs/2026-07-09-tagged-template-filter-design.md
+++ b/docs/superpowers/specs/2026-07-09-tagged-template-filter-design.md
@@ -1,0 +1,87 @@
+# Tagged Template Filter Helper — Design
+
+**Date:** 2026-07-09
+**Status:** Approved (pending final spec review)
+
+## Goal
+
+Let consumers clean strings with a tagged template literal, in the style of
+drizzle-orm's `sql` tag:
+
+```js
+import { createFilter } from 'bad-words'
+
+const filter = createFilter({ placeHolder: '*' })
+filter`bad ass` // 'bad ***'
+```
+
+## Compatibility
+
+Purely additive. Every existing export (`Filter`, `FilterOptions`,
+`LocalList`) is untouched, so all current imports keep working in both CJS and
+ESM. Ships as a semver-**minor** release (4.1.0, `feat:` commit for
+standard-version).
+
+## API
+
+New module `src/tag.ts`, re-exported from `src/index.ts`:
+
+```ts
+export type FilterTag = (
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+) => string
+
+/** Recommended: build a tag bound to its own configured Filter. */
+export function createFilter(options?: FilterOptions): FilterTag
+
+/** Zero-config shorthand, equivalent to createFilter(). */
+export const filter: FilterTag
+```
+
+## Semantics
+
+1. **Cook, then clean.** The tag joins literals and interpolations in order
+   (values coerced with `String()`), then passes the whole cooked string
+   through `Filter#clean`. Output is identical to
+   `new Filter(options).clean(cooked)` — the tag is sugar, not a second
+   filtering code path.
+2. **Interpolations are not trusted.** Unlike drizzle (literals trusted,
+   params escaped), everything is cleaned, including profanity assembled
+   across an interpolation boundary: `` filter`as${'s'}` `` → `'***'`.
+3. **Lazy instance.** Each tag creates its `Filter` on first invocation and
+   reuses it afterward. Importing the module costs nothing; repeated calls do
+   not rebuild the word list. Note: like any long-lived `Filter`, a tag from
+   `createFilter` holds one instance — later `addWords`/`removeWords` calls on
+   other instances don't affect it.
+4. **No new error paths.** Anything `clean()` accepts, the tag accepts.
+
+## Documentation
+
+- README gets a "Tagged templates" section under usage. It leads with
+  `createFilter(options)` as the **recommended** form (works with
+  `placeHolder`, `exclude`, custom lists) and mentions the bare `filter`
+  export as zero-config shorthand.
+- Both exports get typedoc comments consistent with the existing style.
+
+## Testing (TDD, `tests/tag.spec.ts`)
+
+- cleans profanity in literals (`` filter`bad ass` ``)
+- cleans interpolated values (`` filter`you ${'ash0le'}!` ``)
+- cleans profanity assembled across a literal/interpolation boundary
+- coerces non-string interpolations (`String()`)
+- `createFilter` honors `placeHolder`
+- `createFilter` honors `exclude`
+- empty template returns `''`
+- parity: tag output === `Filter#clean` output for the same cooked input
+
+## Implementation plan
+
+1. RED: write `tests/tag.spec.ts` with the cases above; watch them fail
+   (module doesn't exist).
+2. GREEN: implement `src/tag.ts` (`createFilter`, `filter`, `FilterTag`);
+   re-export from `src/index.ts`; watch all tests pass.
+3. Verify: full ava suite, `npm run lint`, `npm run build`,
+   `npm run test:packaging` (confirms the new exports work from the packed
+   tarball in both CJS and ESM).
+4. README section + typedoc comments.

--- a/package.json
+++ b/package.json
@@ -7,11 +7,19 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/esm/index.js",
-      "types": "./dist/index.d.ts"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
+  "files": [
+    "dist"
+  ],
   "directories": {
     "test": "test",
     "src": "src"
@@ -20,17 +28,18 @@
     "prettier": "prettier --write ./src",
     "lint": "eslint ./src",
     "lint:fix": "eslint --fix ./src",
-    "build": "tsc --project tsconfig.cjs.json && tsc --project tsconfig.esm.json",
-    "prepublishOnly": "tsc",
+    "build": "tsc --project tsconfig.cjs.json && tsc --project tsconfig.esm.json && node ./scripts/write-dist-markers.mjs",
+    "prepublishOnly": "npm run build",
     "prepare": "husky && tsc",
     "rc": "standard-version --prerelease && git push --follow-tags && npm publish",
     "release": "standard-version && git push --follow-tags && npm publish",
     "test": "ava",
+    "test:packaging": "./scripts/test-packaging.sh",
     "typedoc": "typedoc --out docs ./src/badwords.ts"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/web-mech/badwords.git"
+    "url": "git+https://github.com/nyvorin/badwords.git"
   },
   "keywords": [
     "curse",

--- a/scripts/test-packaging.sh
+++ b/scripts/test-packaging.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Packs the package and verifies both require() and import() work
+# from a consumer project, exactly as an npm user would experience it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+TARBALL=""
+cleanup() {
+  rm -rf "$TMP"
+  [ -n "$TARBALL" ] && rm -f "$TARBALL"
+}
+trap cleanup EXIT
+
+cd "$ROOT"
+npm run build >/dev/null 2>&1
+TARBALL="$ROOT/$(npm pack --silent 2>/dev/null | tail -1)"
+
+cd "$TMP"
+npm init -y >/dev/null 2>&1
+npm install --no-save --no-audit --no-fund "$TARBALL" >/dev/null 2>&1
+
+cat >consume.cjs <<'EOF'
+const { Filter, filter, createFilter } = require('bad-words')
+const cleaned = new Filter().clean('ash0le')
+if (cleaned !== '******') {
+  throw new Error(`CJS: expected '******', got '${cleaned}'`)
+}
+if (filter`ash0le` !== '******') {
+  throw new Error('CJS: filter tag misbehaved')
+}
+if (createFilter({ placeHolder: 'x' })`ash0le` !== 'xxxxxx') {
+  throw new Error('CJS: createFilter tag misbehaved')
+}
+console.log('ok - CJS require()')
+EOF
+
+cat >consume.mjs <<'EOF'
+import { Filter, filter, createFilter } from 'bad-words'
+const cleaned = new Filter().clean('ash0le')
+if (cleaned !== '******') {
+  throw new Error(`ESM: expected '******', got '${cleaned}'`)
+}
+if (filter`ash0le` !== '******') {
+  throw new Error('ESM: filter tag misbehaved')
+}
+if (createFilter({ placeHolder: 'x' })`ash0le` !== 'xxxxxx') {
+  throw new Error('ESM: createFilter tag misbehaved')
+}
+console.log('ok - ESM import')
+EOF
+
+node consume.cjs
+node consume.mjs
+echo 'ok - packaging'

--- a/scripts/write-dist-markers.mjs
+++ b/scripts/write-dist-markers.mjs
@@ -1,0 +1,10 @@
+// The root package.json declares "type": "module", so Node would treat the
+// compiled CommonJS files in dist/ as ESM. These per-directory markers pin
+// the correct module scope for each build flavor.
+import { writeFileSync } from 'node:fs'
+
+writeFileSync('dist/package.json', JSON.stringify({ type: 'commonjs' }) + '\n')
+writeFileSync(
+  'dist/esm/package.json',
+  JSON.stringify({ type: 'module' }) + '\n',
+)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { Filter, FilterOptions, LocalList } from './badwords.js'
+export { filter, createFilter, FilterTag } from './tag.js'

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,0 +1,51 @@
+import type { FilterOptions } from './badwords.js'
+import { Filter } from './badwords.js'
+
+/**
+ * Tagged template function that returns the cleaned template string.
+ *
+ * @param {TemplateStringsArray} strings - Literal portions of the template.
+ * @param {...unknown} values - Interpolated values, coerced with String().
+ */
+export type FilterTag = (
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+) => string
+
+/**
+ * Create a tagged template function bound to its own Filter.
+ *
+ * The tag joins the template's literals and interpolated values in order,
+ * then cleans the whole string — output is identical to
+ * `new Filter(options).clean(...)` on the cooked string. The Filter is
+ * created lazily on first use and reused for subsequent calls.
+ *
+ * @example
+ * const filter = createFilter({ placeHolder: 'x' })
+ * filter`bad ass` // 'bad xxx'
+ *
+ * @param {FilterOptions} options - Constructor options for the bound Filter.
+ */
+export function createFilter(options: FilterOptions = {}): FilterTag {
+  let instance: Filter | undefined
+
+  return (strings, ...values) => {
+    instance ??= new Filter(options)
+
+    const cooked = strings.reduce(
+      (out, part, i) =>
+        out + part + (i < values.length ? String(values[i]) : ''),
+      '',
+    )
+
+    return instance.clean(cooked)
+  }
+}
+
+/**
+ * Zero-config tagged template filter, equivalent to `createFilter()`.
+ *
+ * @example
+ * filter`bad ass` // 'bad ***'
+ */
+export const filter: FilterTag = createFilter()

--- a/tests/tag.spec.ts
+++ b/tests/tag.spec.ts
@@ -1,0 +1,38 @@
+import test from 'ava'
+import { Filter, filter, createFilter } from '../src/index.js'
+
+test('tag: Should clean profanity in template literals', (t) => {
+  t.is(filter`bad ass`, 'bad ***')
+})
+
+test('tag: Should clean profanity in interpolated values', (t) => {
+  const userInput = 'ash0le'
+  t.is(filter`you ${userInput}!`, 'you ******!')
+})
+
+test('tag: Should clean profanity assembled across an interpolation boundary', (t) => {
+  t.is(filter`as${'s'}`, '***')
+})
+
+test('tag: Should coerce non-string interpolated values', (t) => {
+  t.is(filter`${1} ash0le`, '1 ******')
+})
+
+test('tag: Should return an empty string for an empty template', (t) => {
+  t.is(filter``, '')
+})
+
+test('createFilter: Should honor the placeHolder option', (t) => {
+  const custom = createFilter({ placeHolder: 'x' })
+  t.is(custom`bad ass`, 'bad xxx')
+})
+
+test('createFilter: Should honor the exclude option', (t) => {
+  const custom = createFilter({ exclude: ['ass'] })
+  t.is(custom`bad ass`, 'bad ass')
+})
+
+test('tag: Should match Filter#clean output for the same cooked string', (t) => {
+  const input = "Don't be an ash0le, you bad ass"
+  t.is(filter`Don't be an ${'ash0le'}, you bad ass`, new Filter().clean(input))
+})


### PR DESCRIPTION
## Summary

- **fix(package)**: `require('bad-words')` was broken in 4.0.0 — the root `"type": "module"` made Node parse the compiled CommonJS `dist/index.js` as ESM (`ReferenceError: exports is not defined`). The build now writes per-directory module-scope markers, the exports map uses nested conditions with `types` first, `prepublishOnly` runs the real dual build, and a `files` field trims the tarball from ~60 files to 17. Adds `npm run test:packaging`, which installs the packed tarball into a scratch project and verifies `require()`, `import`, and the new tag exports. Fixes #184, fixes #180.
- **feat(filter)**: drizzle-style tagged template helper. `createFilter(options)` (recommended) returns a tag bound to its own configured `Filter`; the zero-config `filter` export is equivalent to `createFilter()`. Output is identical to `clean()` on the cooked string; interpolations are cleaned, including profanity assembled across boundaries. Purely additive — existing exports unchanged, so this lands as 4.1.0.
- **ci(release)**: switch npm publish to OIDC trusted publishing — `id-token: write`, npm ≥ 11.5.1 on Node 24, no `NPM_TOKEN`; provenance attestations are generated automatically. Repository URL updated to `nyvorin/badwords` to satisfy provenance validation.

## Test plan

- [x] 35 ava tests pass (8 new for the tag)
- [x] `npm run test:packaging` — CJS + ESM consumers against the packed tarball
- [x] TS `NodeNext` resolution checked for `.ts` and `.cts` consumers
- [x] eslint + prettier clean
- [ ] CI green on Node 18.x / 20.x
- [ ] Post-merge: Release workflow publishes 4.1.0 via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)