### PR TITLE
ci(release): run release job on node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          # Node 22 satisfies trusted publishing (>= 22.14) and the
+          # devDependency engine ranges, which reject Node 24 under yarn 1.
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       # Trusted publishing requires npm >= 11.5.1
       - run: npm install -g npm@latest


### PR DESCRIPTION
## Summary

- The 4.1.0 release run failed at `yarn install`: yarn 1 enforces engines and `@ava/typescript@5` rejects Node 24 (`^18.18 || ^20.8 || ^21 || ^22`)
- Node 22 still satisfies npm trusted publishing (requires >= 22.14) and the existing `npm install -g npm@latest` step provides npm >= 11.5.1
- The failed run died before standard-version ran, so no version/tag cleanup is needed — merging this re-triggers the release

## Test plan

- [ ] CI green
- [ ] Post-merge: Release workflow publishes 4.1.0 via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)