### PR TITLE
ci(release): fix OIDC publish registry and version computation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # standard-version needs full history and tags to compute the
+          # version bump; a shallow clone silently downgrades feat to patch.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           # Node 22 satisfies trusted publishing (>= 22.14) and the
@@ -24,4 +28,7 @@ jobs:
       - run: yarn install
       - run: git config --global user.email "action@github.com"
       - run: git config --global user.name "GitHub Action"
-      - run: yarn release
+      # Run the release through npm, not yarn: yarn 1 overrides
+      # npm_config_registry to registry.yarnpkg.com, which breaks OIDC
+      # trusted publishing (it only works against registry.npmjs.org).
+      - run: npm run release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### 4.0.1 (2026-07-15)
-
 ## 4.0.0 (2024-08-18)
 
 ## [4.0.0-0](https://github.com/web-mech/badwords/compare/v3.0.4...v4.0.0-0) (2024-08-18)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bad-words",
-  "version": "4.0.1",
+  "version": "4.0.0",
   "description": "A javascript filter for bad words",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- First OIDC release run failed with `ENEEDAUTH ... registry.yarnpkg.com`: yarn 1 injects `npm_config_registry=https://registry.yarnpkg.com` into child processes, and trusted publishing only works against registry.npmjs.org. The workflow now runs `npm run release`.
- The shallow checkout (no tags/history) made standard-version compute a patch bump (4.0.1) instead of minor; now `fetch-depth: 0`.
- Reverts the phantom `chore(release): 4.0.1` commit; the unpublished `v4.0.1` tag has been deleted from the remote. Next release computes commits since `v4.0.0` → 4.1.0.

## Test plan

- [ ] CI green
- [ ] Post-merge: Release workflow publishes bad-words@4.1.0 to npmjs via OIDC with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)